### PR TITLE
feat: add proxy control tab

### DIFF
--- a/Idealista_extensao/background.js
+++ b/Idealista_extensao/background.js
@@ -137,3 +137,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return;
   }
 });
+
+// Limpeza automática: desativa o proxy assim que o service worker inicializa
+disableProxy().catch(e => console.error("[proxy] Erro ao desativar proxy na inicialização:", e));

--- a/Idealista_extensao/popup-ui.js
+++ b/Idealista_extensao/popup-ui.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const panels = {
     links: document.getElementById('panel-links'),
     itens: document.getElementById('panel-itens'),
+    proxy: document.getElementById('panel-proxy'),
   };
 
   function activate(tabKey) {
@@ -19,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // clique nas abas
   tabs.forEach(btn => {
     btn.addEventListener('click', () => {
-      const key = btn.dataset.tab; // "links" ou "itens"
+      const key = btn.dataset.tab; // "links", "itens" ou "proxy"
       activate(key);
     });
   });

--- a/Idealista_extensao/popup.html
+++ b/Idealista_extensao/popup.html
@@ -29,6 +29,9 @@
     <button class="tab-btn" data-tab="itens" id="tab-itens" role="tab" aria-selected="false" aria-controls="panel-itens">
       Itens
     </button>
+    <button class="tab-btn" data-tab="proxy" id="tab-proxy" role="tab" aria-selected="false" aria-controls="panel-proxy">
+      Proxy
+    </button>
   </div>
 
   <!-- Aba 1: Links -->
@@ -38,15 +41,20 @@
 
   <!-- Aba 2: Itens -->
   <section id="panel-itens" class="panel" role="tabpanel" aria-labelledby="tab-itens">
+    <button id="extractItems" aria-label="Extrair itens em JSON com paginação">Extrair Itens (JSON)</button>
+    <button id="stopExtract" aria-label="Parar e baixar JSON parcial">Parar e baixar JSON</button>
+  </section>
+
+  <!-- Aba 3: Proxy -->
+  <section id="panel-proxy" class="panel" role="tabpanel" aria-labelledby="tab-proxy">
     <div id="proxyStatus" style="font-size:12px;margin:4px 0;">
       Proxy: <strong id="proxyState">desativado</strong>
     </div>
+    <button id="toggleProxy">Ativar Proxy</button>
     <div id="proxyIpBox" style="font-size:12px;color:#444;"></div>
     <label for="extraDomains" style="font-size:12px;display:block;margin-top:4px;">Domínios adicionais (um por linha)</label>
     <textarea id="extraDomains" rows="2" style="width:100%;"></textarea>
     <button id="testProxyIp">Testar IP (via proxy)</button>
-    <button id="extractItems" aria-label="Extrair itens em JSON com paginação">Extrair Itens (JSON)</button>
-    <button id="stopExtract" aria-label="Parar e baixar JSON parcial">Parar e baixar JSON</button>
   </section>
 
   <!-- Scripts externos (sem inline, para respeitar CSP) -->


### PR DESCRIPTION
## Summary
- add dedicated tab with controls to enable/disable proxy
- ask to enable proxy before extracting links or items
- automatically disable proxy on service worker startup to guarantee clean state

## Testing
- `node --check Idealista_extensao/popup.js`
- `node --check Idealista_extensao/popup-ui.js`
- `node --check Idealista_extensao/background.js`


------
https://chatgpt.com/codex/tasks/task_e_688eaec23328832db9c058f60e29a5df