### PR TITLE
Sort auto-loaded list by quantity

### DIFF
--- a/Idealista_extensao_v1/popup.js
+++ b/Idealista_extensao_v1/popup.js
@@ -682,12 +682,12 @@ document.addEventListener("DOMContentLoaded", () => {
             itens.forEach(item => {
               const linkElem = item.querySelector('a');
               const spanElem = item.querySelector('.breadcrumb-navigation-sidenote');
-              if(linkElem && spanElem){
-                  resultado.push({
-                      nome: linkElem.innerText.trim(),
-                      link: linkElem.getAttribute('href'),
-                      quantidade: spanElem.innerText.trim()
-                  });
+              if (linkElem && spanElem) {
+                resultado.push({
+                  nome: linkElem.innerText.trim(),
+                  link: linkElem.getAttribute('href'),
+                  quantidade: parseInt(spanElem.innerText.replace(/\D/g, ''), 10)
+                });
               }
             });
             return resultado;
@@ -696,6 +696,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!Array.isArray(result) || result.length === 0) {
           loteLog.textContent = 'Nenhum bairro/cidade encontrado na página ativa.';
         } else {
+          result.sort((a, b) => b.quantidade - a.quantidade);
           loteUrlsTextarea.value = JSON.stringify(result, null, 2);
           loteLog.textContent = `Lista carregada automaticamente: ${result.length} itens.`;
         }


### PR DESCRIPTION
## Summary
- Parse extracted `quantidade` values to numbers when auto-loading region list
- Sort auto-loaded results in descending order and update textarea with sorted JSON

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check Idealista_extensao_v1/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68936eb3a6dc832d8253c9dbb55b1e50