### PR TITLE
fix: parse quantity with thousands separators

### DIFF
--- a/Idealista_extensao_v1/popup.js
+++ b/Idealista_extensao_v1/popup.js
@@ -715,7 +715,9 @@ document.addEventListener("DOMContentLoaded", () => {
             itens.forEach(li => {
               const linkElem = li.querySelector('a');
               const spanElem = li.querySelector('.breadcrumb-navigation-sidenote');
-              const quantidade = spanElem ? parseInt(spanElem.innerText.trim(), 10) : NaN;
+              const quantidade = spanElem
+                ? parseInt(spanElem.innerText.replace(/\./g, '').trim(), 10)
+                : NaN;
               if (linkElem && !isNaN(quantidade)) {
                 resultado.push({
                   nome: linkElem.innerText.trim(),


### PR DESCRIPTION
## Summary
- handle thousands separators when parsing quantity in popup loader

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893933ddee0832dbf142d0a5f441436